### PR TITLE
[PKG-4971] 1.2 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,15 @@ test:
     - pytest
 
 about:
-  home: https://github.com/datamade/simplecosine
+  home: https://github.com/dedupeio/simplecosine
+  dev_url: https://github.com/dedupeio/simplecosine
+  doc_url: https://github.com/dedupeio/simplecosine/blob/master/README.md
   summary: Simple cosine distance
+  description: |
+    Part of the Dedupe.io cloud service and open source toolset for 
+    de-duplicating and finding fuzzy matches in your data.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,40 @@
 {% set name = "simplecosine" %}
 {% set version = "1.2" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/simplecosine-{{ version }}.tar.gz
-  sha256: 216ae262f5e5d2daaa7740296f9308c9fc024e7d7551412c7839065748b3bf02
+  url: https://github.com/dedupeio/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 09d2d356ecf5bbaae249f26b30b3128a56899dd6f0d34fbf7ff779a7cd2cd15e
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
     - numpy
-    - python >=3.6
+    - python
 
 test:
+  source_files:
+    - tests
   imports:
     - simplecosine.cosine
   commands:
     - pip check
+    - pytest tests -v
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/datamade/simplecosine


### PR DESCRIPTION
simplecosine 1.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4971]
- [Upstream repository](https://github.com/datamade/simplecosine)

### Explanation of changes:

- ⚠️ There is no license file in the upstream. `setup.py` [links to a generic version of the MIT license](https://github.com/dedupeio/simplecosine/blob/78bacea07dbe96373dd35538ed71a8b9dbc05766/setup.py#L16), and that metadata is used [on pypi](https://pypi.org/project/simplecosine/). Conda-forge simply added a generic MIT license file with no name or year, which is included in this feedstock.


[PKG-4971]: https://anaconda.atlassian.net/browse/PKG-4971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ